### PR TITLE
Correct the name of purchase email template in Book.js

### DIFF
--- a/server/models/Book.js
+++ b/server/models/Book.js
@@ -236,7 +236,7 @@ class BookClass {
 
     User.findByIdAndUpdate(user.id, { $addToSet: { purchasedBookIds: book._id } }).exec();
 
-    const template = await getEmailTemplate('purchased', {
+    const template = await getEmailTemplate('purchase', {
       userName: user.displayName,
       bookTitle: book.name,
       bookUrl: `https://builderbook.org/books/${book.slug}/introduction`,


### PR DESCRIPTION
based on: https://github.com/builderbook/builderbook/issues/87, the correct email template name should be: 'purchase' instead of 'purchased'