### PR TITLE
Fixed mongoose URL string parser deprecation warning

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -23,7 +23,7 @@ const ROOT_URL = dev ? `http://localhost:${port}` : 'https://builderbook.org';
 
 const MONGO_URL = dev ? process.env.MONGO_URL_TEST : process.env.MONGO_URL;
 
-mongoose.connect(MONGO_URL);
+mongoose.connect(MONGO_URL, { useNewUrlParser: true });
 
 const sessionSecret = process.env.SESSION_SECRET;
 


### PR DESCRIPTION
For mongoose version >=5.2, add additional argument to resolve String URL parser deprecation warning.

Source:
https://stackoverflow.com/questions/50448272/avoid-current-url-string-parser-is-deprecated-warning-by-setting-usenewurlpars