### PR TITLE
Update old SnackbarContentProps to ContentProps

### DIFF
--- a/book/4-end/components/Notifier.js
+++ b/book/4-end/components/Notifier.js
@@ -36,7 +36,7 @@ class Notifier extends React.Component {
         autoHideDuration={5000}
         onClose={this.handleSnackbarRequestClose}
         open={this.state.open}
-        snackbarcontentprops={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />

--- a/book/5-end/components/Notifier.js
+++ b/book/5-end/components/Notifier.js
@@ -36,7 +36,7 @@ class Notifier extends React.Component {
         autoHideDuration={5000}
         onClose={this.handleSnackbarRequestClose}
         open={this.state.open}
-        snackbarcontentprops={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />

--- a/book/5-start/components/Notifier.js
+++ b/book/5-start/components/Notifier.js
@@ -36,7 +36,7 @@ class Notifier extends React.Component {
         autoHideDuration={5000}
         onClose={this.handleSnackbarRequestClose}
         open={this.state.open}
-        snackbarcontentprops={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />

--- a/book/6-end/components/Notifier.js
+++ b/book/6-end/components/Notifier.js
@@ -36,7 +36,7 @@ class Notifier extends React.Component {
         autoHideDuration={5000}
         onClose={this.handleSnackbarRequestClose}
         open={this.state.open}
-        snackbarcontentprops={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />

--- a/book/6-start/components/Notifier.js
+++ b/book/6-start/components/Notifier.js
@@ -36,7 +36,7 @@ class Notifier extends React.Component {
         autoHideDuration={5000}
         onClose={this.handleSnackbarRequestClose}
         open={this.state.open}
-        snackbarcontentprops={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />

--- a/book/7-end/components/Notifier.js
+++ b/book/7-end/components/Notifier.js
@@ -36,7 +36,7 @@ class Notifier extends React.Component {
         autoHideDuration={5000}
         onClose={this.handleSnackbarRequestClose}
         open={this.state.open}
-        snackbarcontentprops={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />

--- a/book/7-start/components/Notifier.js
+++ b/book/7-start/components/Notifier.js
@@ -36,7 +36,7 @@ class Notifier extends React.Component {
         autoHideDuration={5000}
         onClose={this.handleSnackbarRequestClose}
         open={this.state.open}
-        snackbarcontentprops={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />

--- a/book/8-end/components/Notifier.js
+++ b/book/8-end/components/Notifier.js
@@ -36,7 +36,7 @@ class Notifier extends React.Component {
         autoHideDuration={5000}
         onClose={this.handleSnackbarRequestClose}
         open={this.state.open}
-        snackbarcontentprops={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />

--- a/book/8-start/components/Notifier.js
+++ b/book/8-start/components/Notifier.js
@@ -36,7 +36,7 @@ class Notifier extends React.Component {
         autoHideDuration={5000}
         onClose={this.handleSnackbarRequestClose}
         open={this.state.open}
-        snackbarcontentprops={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />

--- a/components/Notifier.js
+++ b/components/Notifier.js
@@ -36,7 +36,7 @@ class Notifier extends React.Component {
         autoHideDuration={3000}
         onClose={this.handleSnackbarClose}
         open={this.state.open}
-        snackbarcontentprops={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />

--- a/tutorials/4-end/components/Notifier.js
+++ b/tutorials/4-end/components/Notifier.js
@@ -42,7 +42,7 @@ class Notifier extends React.Component {
         autoHideDuration={3000}
         onClose={this.handleSnackbarClose}
         open={this.state.open}
-        SnackbarContentProps={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />

--- a/tutorials/7-end-production-server/components/Notifier.js
+++ b/tutorials/7-end-production-server/components/Notifier.js
@@ -42,7 +42,7 @@ class Notifier extends React.Component {
         autoHideDuration={3000}
         onClose={this.handleSnackbarClose}
         open={this.state.open}
-        SnackbarContentProps={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />

--- a/tutorials/8-end-layout-HOC/components/Notifier.js
+++ b/tutorials/8-end-layout-HOC/components/Notifier.js
@@ -42,7 +42,7 @@ class Notifier extends React.Component {
         autoHideDuration={3000}
         onClose={this.handleSnackbarClose}
         open={this.state.open}
-        SnackbarContentProps={{
+        ContentProps={{
           'aria-describedby': 'snackbar-message-id',
         }}
       />


### PR DESCRIPTION
Per https://github.com/mui-org/material-ui/pull/11203, `SnackbarContentProps` has been updated to `ContentProps`.

```JSX
       <Snackbar
-        SnackbarContentProps={{ 'aria-describedby': 'notification-message' }}
+        ContentProps={{ 'aria-describedby': 'notification-message' }}
```