### PR TITLE
remove the second .next

### DIFF
--- a/book/1-start/.gitignore
+++ b/book/1-start/.gitignore
@@ -11,4 +11,3 @@ npm-debug.log
 node_modules/
 .coverage
 .env
-.next


### PR DESCRIPTION
there was 2 .next in the .gitignore file

<br/><hr/><details>
          <summary>Click to see <b>Hill for pull request #210</b></summary>
          <div><img src="https://async-github-hills.s3.amazonaws.com/builderbook-builderbook/210.png" alt="Single issue hill" class="s3-image" width="100%" /></div></details>
          <details><summary>Click to see <b>Hill for all pull requests </b></summary><div>
          <img src="https://async-github-hills.s3.amazonaws.com/builderbook-builderbook/all-pull-request-hill.png" alt="All issue hill" class="s3-image" width="100%" /></div></details>
          
created by [Async](https://async-await.com/)