### PR TITLE
Updating .eslintrc with prefer arrow functions rule

### DIFF
--- a/book/1-end/.eslintrc.js
+++ b/book/1-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/2-begin/.eslintrc.js
+++ b/book/2-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/2-end/.eslintrc.js
+++ b/book/2-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/3-begin/.eslintrc.js
+++ b/book/3-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/3-end/.eslintrc.js
+++ b/book/3-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/4-begin/.eslintrc.js
+++ b/book/4-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/4-end/.eslintrc.js
+++ b/book/4-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/5-begin/.eslintrc.js
+++ b/book/5-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/5-end/.eslintrc.js
+++ b/book/5-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/6-begin/.eslintrc.js
+++ b/book/6-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/6-end/.eslintrc.js
+++ b/book/6-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/7-begin/.eslintrc.js
+++ b/book/7-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/7-end/.eslintrc.js
+++ b/book/7-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/8-begin/.eslintrc.js
+++ b/book/8-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/8-end/.eslintrc.js
+++ b/book/8-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/9-begin/.eslintrc.js
+++ b/book/9-begin/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/book/9-end/.eslintrc.js
+++ b/book/9-end/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {

--- a/builderbook/.eslintrc.js
+++ b/builderbook/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'camelcase': 'off',
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-mixed-operators': 'off',
+    'prefer-arrow-callback': 'error',
     'prefer-destructuring': [
       'error',
       {


### PR DESCRIPTION
As per https://github.com/builderbook/builderbook/pull/434. This PR contains an updated `.eslintrc` with the `prefer-arrow-callback` rule to avoid confusion in the first chapter.

@klyburke 